### PR TITLE
Fixing an id mismatch

### DIFF
--- a/src/main/java/org/softwire/training/db/daos/RegionsDao.java
+++ b/src/main/java/org/softwire/training/db/daos/RegionsDao.java
@@ -43,7 +43,7 @@ public class RegionsDao {
                     handle.createUpdate("INSERT INTO location_region (location_id, region_id) " +
                             "VALUES (:location_id, :region_id)")
                             .bind("location_id", locationId)
-                            .bind("region_id", region.getRegionId())
+                            .bind("region_id", regionId)
                             .execute();
                 }
                 allLocationsInserted = true;


### PR DESCRIPTION
when storing a region location, the region's id value in the database  does not match the 'region_id' in the "location_region" table (off by 1). This fix ensures that the 'region_id' matches that of the corresponding region in the "regions" table